### PR TITLE
Fixed glibc issue on linux arm64

### DIFF
--- a/.github/workflows/reusable-build-nuget-package.yaml
+++ b/.github/workflows/reusable-build-nuget-package.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build PedersenCommitment Nuget package
     needs:
       - build-rust-artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     env:
       project: src/ProjectOrigin.PedersenCommitment

--- a/src/Native/Cargo.toml
+++ b/src/Native/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ['lib', 'cdylib', 'staticlib']
+crate-type = ['cdylib']
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Had issue when using updated to new library specifically a `'GLIBC_2.33' not found` which from previous experience has to do with it being compiled on ubuntu 22:04 since it uses a newer version, regressing to 20.04 should solve the issue.

Also removed some unused crate target.  

```log
[xUnit.net 00:00:00.53]     ProjectOrigin.Electricity.IntegrationTests.FlowTests.IssueConsumptionCertificate_Success [FAIL]
  Failed ProjectOrigin.Electricity.IntegrationTests.FlowTests.IssueConsumptionCertificate_Success [97 ms]
  Error Message:
   System.DllNotFoundException : Unable to load shared library 'rust_ffi' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/runtimes/linux-arm64/native/rust_ffi.so: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.5/rust_ffi.so: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/rust_ffi.so: cannot open shared object file: No such file or directory
/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/runtimes/linux-arm64/native/librust_ffi.so)
/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.5/librust_ffi.so: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/librust_ffi.so: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/runtimes/linux-arm64/native/rust_ffi: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.5/rust_ffi: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/rust_ffi: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/runtimes/linux-arm64/native/librust_ffi: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.5/librust_ffi: cannot open shared object file: No such file or directory
/workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/bin/Debug/net7.0/librust_ffi: cannot open shared object file: No such file or directory

  Stack Trace:
     at ProjectOrigin.PedersenCommitment.Ristretto.Scalar.Native.Random()
   at ProjectOrigin.PedersenCommitment.Ristretto.Scalar.Random()
   at ProjectOrigin.PedersenCommitment.SecretCommitmentInfo..ctor(UInt32 message)
   at ProjectOrigin.Electricity.IntegrationTests.FlowTests.IssueConsumptionCertificate_Success() in /workspaces/registry/src/ProjectOrigin.Electricity.IntegrationTests/FlowTests.cs:line 53
--- End of stack trace from previous location ---
```